### PR TITLE
Fixed memory leak

### DIFF
--- a/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashListener.java
+++ b/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashListener.java
@@ -27,11 +27,10 @@ public class LeashListener implements Listener {
 
         if (!tameable.isLeashed() || !tameable.isTamed()) return;
 
-        tameablePrevPos.put(entity.getEntityId(), entity.getLocation());
-
         Entity leashHolder = tameable.getLeashHolder();
         if (!(leashHolder instanceof Player)) {
             event.setCancelled(true);
+            tameablePrevPos.put(entity.getEntityId(), entity.getLocation());
         }
     }
 
@@ -43,6 +42,7 @@ public class LeashListener implements Listener {
         if (!(leashHolder instanceof Player)){
             Entity entity = event.getEntity();
             entity.teleport(tameablePrevPos.get(entity.getEntityId()));
+            tameablePrevPos.remove(entity.getEntityId());
             event.setCancelled(true);
         }
     }

--- a/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashListener.java
+++ b/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashListener.java
@@ -14,7 +14,8 @@ import org.bukkit.event.entity.EntityUnleashEvent;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EventListener implements Listener {
+public class LeashListener implements Listener {
+
     private Map<Integer, Location> tameablePrevPos = new HashMap<>();
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -24,13 +25,9 @@ public class EventListener implements Listener {
         if (!(entity instanceof Tameable)) return;
         Tameable tameable = (Tameable) entity;
 
-        boolean isTamed = tameable.isTamed();
-        if (!isTamed) return;
+        if (!tameable.isLeashed() || !tameable.isTamed()) return;
 
         tameablePrevPos.put(entity.getEntityId(), entity.getLocation());
-
-        boolean isLeashed = tameable.isLeashed();
-        if (!isLeashed) return;
 
         Entity leashHolder = tameable.getLeashHolder();
         if (!(leashHolder instanceof Player)) {

--- a/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashedCatTeleportFix.java
+++ b/src/main/java/leashedcatteleportfix/leashedcatteleportfix/LeashedCatTeleportFix.java
@@ -5,6 +5,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class LeashedCatTeleportFix extends JavaPlugin {
     @Override
     public void onEnable() {
-        getServer().getPluginManager().registerEvents(new EventListener(), this);
+        getServer().getPluginManager().registerEvents(new LeashListener(), this);
     }
 }


### PR DESCRIPTION
You are putting entities into a map and never removing them. This leads to a map containing values that are no longer used, but are kept in memory.

Because of the strange workspace setup I am not going to test the following presumption I have:
If you are cancelling the teleport event, is it really necessary to teleport the entity in the EntityUnleashEvent?